### PR TITLE
fix: update production types from "Commercial" to correct categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fotografi-frame",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fotografi-frame",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@videojs/react": "^10.0.0-beta.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fotografi-frame",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/productions/_components/SelectedProductionsGrid.tsx
+++ b/src/app/productions/_components/SelectedProductionsGrid.tsx
@@ -12,13 +12,13 @@ const SELECTED_PRODUCTIONS_IMAGES: {
     description: "Luxury Real Estate Campaign",
     src: images.birthdays.carousels[0][0],
     title: "Concrete Dreams",
-    type: "Commercial",
+    type: "Documentario",
   },
   {
     description: "Luxury Real Estate Campaign",
     src: images.birthdays.carousels[0][1],
     title: "Concrete Dreams",
-    type: "Commercial",
+    type: "Videoclip",
   },
   {
     description: "Luxury Real Estate Campaign",


### PR DESCRIPTION
# What this PR does?

- [x] Change category names of selected productions in the `/productions` page.

## Prerequisites

- [x] Have I updated the `package.json`'s version per semver?
- [x] Did I follow the [contribution guidelines](CONTRIBUTING.md)?
