### PR TITLE
Update production statistics and correct image paths for Hirpinia Film Lab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fotografi-frame",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fotografi-frame",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@videojs/react": "^10.0.0-beta.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fotografi-frame",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/hirpinia-film-lab/page.tsx
+++ b/src/app/hirpinia-film-lab/page.tsx
@@ -26,6 +26,8 @@ const TOGETHER_PICTURES_STATS: [string, string][] = [
   ["8", "Produzioni"],
 ];
 
+const BEHIND_THE_LENS_IMAGE_COUNT_PER_LAYOUT = 5;
+
 export default function HirpiniaFilmLab() {
   const { isNavOpen } = useNav();
   const mainScrollBarRef = useRef(null);
@@ -273,8 +275,8 @@ export default function HirpiniaFilmLab() {
                       relative
                       group
                       opacity-80
-                      ${index % 5 === 0 ? "md:col-span-2 md:row-span-2" : ""}
-                      ${index % 5 === 2 ? "md:row-span-2" : ""}
+                      ${index % BEHIND_THE_LENS_IMAGE_COUNT_PER_LAYOUT === 0 ? "md:col-span-2 md:row-span-2" : ""}
+                      ${index % BEHIND_THE_LENS_IMAGE_COUNT_PER_LAYOUT === 2 ? "md:row-span-2" : ""}
                       overflow-hidden
                     `}
                     key={`training-area-${index}`}

--- a/src/app/hirpinia-film-lab/page.tsx
+++ b/src/app/hirpinia-film-lab/page.tsx
@@ -23,7 +23,7 @@ gsap.registerPlugin(useGSAP, ScrollTrigger);
 const TOGETHER_PICTURES_STATS: [string, string][] = [
   ["100+", "Partecipanti"],
   ["09", "Reparti"],
-  ["6", "Produzioni"],
+  ["8", "Produzioni"],
 ];
 
 export default function HirpiniaFilmLab() {
@@ -273,8 +273,8 @@ export default function HirpiniaFilmLab() {
                       relative
                       group
                       opacity-80
-                      ${index === 0 ? "md:col-span-2 md:row-span-2" : ""}
-                      ${index === 2 ? "md:row-span-2" : ""}
+                      ${index % 5 === 0 ? "md:col-span-2 md:row-span-2" : ""}
+                      ${index % 5 === 2 ? "md:row-span-2" : ""}
                       overflow-hidden
                     `}
                     key={`training-area-${index}`}

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -125,96 +125,107 @@ const images = {
   header: HeaderImage,
   hirpiniaFilmLab: {
     behindTheLensSectionMedia: [
-      "https://github.com/NotReallyEight/frame-group-website-assets/raw/refs/heads/main/hirpinia-film-lab/7Q5A0951.mp4",
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7134.webp",
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7211.webp",
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7161.webp",
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7145.webp",
+      "https://github.com/NotReallyEight/frame-group-website-assets/raw/refs/heads/main/hirpinia-film-lab/home/7Q5A0951.mp4",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7134.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/communicationAndMarketing/7Q5A7211.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7161.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7145.webp",
+      "https://github.com/NotReallyEight/frame-group-website-assets/raw/refs/heads/main/hirpinia-film-lab/home/CAM_A_7291.mp4",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/home/7Q5A6511.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/home/7Q5A6572.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/home/7Q5A6560.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/home/7Q5A6546.webp",
     ],
     heroBg: HirpiniaFilmLabHeroBg,
     theVisionGrid: [
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7211.webp",
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A1000.webp",
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7142.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/communicationAndMarketing/7Q5A7211.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A1000.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7142.webp",
     ],
     together:
-      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7448.webp",
+      "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/home/7Q5A7448.webp",
     trainingAreas: {
       artDepartment:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7613.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7613.webp",
       actors:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7341.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7341.webp",
       communicationAndMarketing:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7211.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/communicationAndMarketing/7Q5A7211.webp",
       photography:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
       music:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
       postProduction:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
       production:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
       direction:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/direction/7Q5A6561.webp",
       setDesign:
-        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
     },
     trainingAreaDedicatedPages: {
       artDepartment: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7632.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7632.webp",
         images: [
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7613.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7632.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7644.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7679.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7705.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/_DSC7706.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/20260403_175301.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/20260403_183657.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7613.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7632.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7644.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7679.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7705.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/_DSC7706.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/20260403_175301.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/artDepartment/20260403_183657.webp",
         ],
       },
       actors: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7341.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7341.webp",
         images: [
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A1000.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7134.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7145.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7261.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7341.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A1000.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7134.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7145.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7261.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A7341.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A6651.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/actors/7Q5A6656.webp",
         ],
       },
       communicationAndMarketing: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7211.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/communicationAndMarketing/7Q5A7211.webp",
         images: [
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7211.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/communicationAndMarketing/7Q5A7211.webp",
         ],
       },
       photography: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
         images: [
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7142.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7161.webp",
-          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7142.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7161.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A6549.webp",
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A6658.webp",
         ],
       },
       music: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
         images: [],
       },
       postProduction: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
         images: [],
       },
       production: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
         images: [],
       },
       direction: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
-        images: [],
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/direction/7Q5A6561.webp",
+        images: [
+          "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/direction/7Q5A6561.webp",
+        ],
       },
       setDesign: {
-        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/7Q5A7192.webp",
+        bg: "https://raw.githubusercontent.com/NotReallyEight/frame-group-website-assets/refs/heads/main/hirpinia-film-lab/photography/7Q5A7192.webp",
         images: [],
       },
     },


### PR DESCRIPTION
This pull request updates the `Hirpinia Film Lab` page and related image assets to improve content accuracy and organization. The main changes include updating the statistics displayed, enhancing the layout logic for training areas, and reorganizing the image asset URLs for better maintainability and clarity.

**Content and Data Updates:**

* Updated the "Produzioni" statistic from 6 to 8 in the `TOGETHER_PICTURES_STATS` array to reflect the latest data.

**UI and Layout Improvements:**

* Changed the logic for grid item sizing in the training areas section to use a modulo operation, improving layout flexibility and consistency across different items.

**Image Asset Organization and Expansion:**

* Reorganized image and video asset URLs in `src/utils/images.ts` by categorizing them into subfolders (e.g., `actors/`, `artDepartment/`, `photography/`, etc.), improving clarity and maintainability.
* Added new images and videos to several sections, such as `behindTheLensSectionMedia`, `theVisionGrid`, and dedicated training area pages, providing richer and more specific media content.
* Updated references for training area backgrounds and gallery images to point to their respective subfolders, ensuring correct and context-specific media is used throughout the site.

_Made by Copilot_

## Prerequisites

- [x] Have I updated the `package.json`'s version per semver?
- [x] Did I follow the [contribution guidelines](CONTRIBUTING.md)?
