### PR TITLE
fix: correct production count in TOGETHER_PICTURES_STATS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fotografi-frame",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fotografi-frame",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@videojs/react": "^10.0.0-beta.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fotografi-frame",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/hirpinia-film-lab/page.tsx
+++ b/src/app/hirpinia-film-lab/page.tsx
@@ -23,7 +23,7 @@ gsap.registerPlugin(useGSAP, ScrollTrigger);
 const TOGETHER_PICTURES_STATS: [string, string][] = [
   ["100+", "Partecipanti"],
   ["09", "Reparti"],
-  ["8", "Produzioni"],
+  ["9", "Produzioni"],
 ];
 
 const BEHIND_THE_LENS_IMAGE_COUNT_PER_LAYOUT = 5;

--- a/src/app/hirpinia-film-lab/page.tsx
+++ b/src/app/hirpinia-film-lab/page.tsx
@@ -22,7 +22,7 @@ gsap.registerPlugin(useGSAP, ScrollTrigger);
 
 const TOGETHER_PICTURES_STATS: [string, string][] = [
   ["100+", "Partecipanti"],
-  ["09", "Reparti"],
+  ["9", "Reparti"],
   ["9", "Produzioni"],
 ];
 


### PR DESCRIPTION
# What this PR does?

This pull request makes a minor update to the statistics displayed on the Hirpinia Film Lab page. Specifically, it corrects the number of "Produzioni" from 8 to 9.

* Updated the `TOGETHER_PICTURES_STATS` array in `page.tsx` to display "9" instead of "8" for the number of productions ("Produzioni").

## Prerequisites

- [x] Have I updated the `package.json`'s version per semver?
- [x] Did I follow the [contribution guidelines](CONTRIBUTING.md)?
