### PR TITLE
fix: update maintenance configuration to use environment variable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ const config = {
     process.env.NODE_ENV === "production"
       ? "https://framegroup.it"
       : "http://localhost:3000",
-  maintenance: true,
+  maintenance: (process.env.MAINTENANCE ?? "true") === "true",
   maintenanceAllowedRoutes: ["/hirpinia-film-lab"],
 };
 


### PR DESCRIPTION
# What this PR does?

This pull request updates the way maintenance mode is configured in the `src/config.ts` file. Instead of hardcoding maintenance mode as always enabled, it now reads the `MAINTENANCE` environment variable to determine if maintenance mode should be active.

Configuration improvements:

* Changed the `maintenance` property to be dynamically set based on the `MAINTENANCE` environment variable, defaulting to `"true"` if not set.