### PR TITLE
Add step to set BACKSTAGE_UPLOAD_SECRET in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
         node-version: [24.x]
     steps:
       - uses: actions/checkout@v6
+      - name: Set BACKSTAGE_UPLOAD_SECRET if missing
+        run: |
+          echo "BACKSTAGE_UPLOAD_SECRET=${BACKSTAGE_UPLOAD_SECRET:-dummy-secret-in-PR}" >> $GITHUB_ENV
       - name: Tests with Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
# What this PR does?

This pull request makes a small update to the GitHub Actions workflow. It ensures that the `BACKSTAGE_UPLOAD_SECRET` environment variable is always set during the test job, defaulting to a dummy value if not already provided. This helps prevent errors related to missing secrets in pull requests.

* Added a step to set `BACKSTAGE_UPLOAD_SECRET` to a default value (`dummy-secret-in-PR`) if it is not already defined in the environment, improving workflow reliability for PRs.

_Summary made by Copilot._

## Prerequisites

- [x] Have I updated the `package.json`'s version per semver?
- [x] Did I follow the [contribution guidelines](CONTRIBUTING.md)?
